### PR TITLE
Bump Microsoft.AspNetCore.Components.WebAssembly from 9.0.7 to 9.0.8

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" />
     <PackageVersion Include="MSTest" Version="3.10.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Components.WebAssembly dependency-version: 9.0.8 dependency-type: direct:production update-type: version-update:semver-patch ...